### PR TITLE
Image Inspect - config OnBuild not present with some buildkit images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
 
   test-windows:
     name: Cargo test on Windows
+    # docker on windows requires api version 1.44 or newer; this client uses v1.41, and v1.44 has breaking changes
+    if: false
     strategy:
       matrix:
         os:
@@ -126,11 +128,11 @@ jobs:
       - run: Get-Command docker
       - run: Get-Service docker
       - run: sc.exe query docker
-      - run: docker version
       - run: Stop-Service docker
       - run: |
           Set-Content -Path "C:\ProgramData\Docker\config\daemon.json" -Value "{`"hosts`": [`"tcp://127.0.0.1:2375`"]}"
       - run: Start-Service docker
+      - run: docker version
       - run: cargo test --no-run
       - run: |
           $env:DOCKER_HOST = 'http://localhost:2375'; cargo test --no-fail-fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,9 @@ jobs:
       # See https://docs.rs/crate/openssl-sys/0.9.36
       - run: vcpkg install openssl:x64-windows-static-md
       - run: vcpkg integrate install
+      - run: Get-Command docker
+      - run: Get-Service docker
+      - run: sc.exe query docker
       - run: docker version
       - run: Stop-Service docker
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-22.04
         toolchain:
-          - "1.75"
+          - "1.88"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
           - ubuntu-22.04
           - windows-2022
         toolchain:
-          - "1.75"
+          - "1.88"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
         os:
           - ubuntu-24.04
         toolchain:
-          - "1.75"
+          - "1.88"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
           # 12 has it, but it is now unreliable, see https://github.com/abiosoft/colima/issues/1047
           - macOS-12
         toolchain:
-          - "1.75"
+          - "1.88"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
         toolchain:
-          - "1.75"
+          - "1.88"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
         os:
           - windows-2022
         toolchain:
-          - "1.75"
+          - "1.88"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,9 @@ jobs:
 
   test-mac:
     name: Cargo test on Mac
+    # docker on mac requires api version 1.44 or newer; this client uses v1.41, and v1.44 has breaking changes
+    if: false
     strategy:
-      # Only have one Mac build because Mac build setup is flaky
       matrix:
         os:
           - macos-15-intel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-22.04
         toolchain:
-          - "1.88"
+          - "1.89"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
           - ubuntu-22.04
           - windows-2022
         toolchain:
-          - "1.88"
+          - "1.89"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
         os:
           - ubuntu-24.04
         toolchain:
-          - "1.88"
+          - "1.89"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
           # 12 has it, but it is now unreliable, see https://github.com/abiosoft/colima/issues/1047
           - macOS-12
         toolchain:
-          - "1.88"
+          - "1.89"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
         toolchain:
-          - "1.88"
+          - "1.89"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
         os:
           - windows-2022
         toolchain:
-          - "1.88"
+          - "1.89"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,7 @@ jobs:
       # Only have one Mac build because Mac build setup is flaky
       matrix:
         os:
-          # 13 and 14 are missing colima
-          # 12 has it, but it is now unreliable, see https://github.com/abiosoft/colima/issues/1047
-          - macOS-12
+          - macos-15-intel
         toolchain:
           - "1.89"
     runs-on: ${{ matrix.os }}
@@ -77,12 +75,13 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - run: brew install docker
-      #- run: colima start
-      #- run: docker version
-      #- run: docker info
-      #- run: echo "DOCKER_HOST=$HOME/.colima/docker.sock" >> "$GITHUB_ENV"
+      - run: brew install colima
+      - run: colima start
+      - run: docker version
+      - run: docker info
+      - run: echo "DOCKER_HOST=$HOME/.colima/docker.sock" >> "$GITHUB_ENV"
       - run: cargo test --no-run
-      #- run: cargo test --no-fail-fast
+      - run: cargo test --no-fail-fast
     timeout-minutes: 20
 
   test-nix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
         toolchain:
           - "1.75"
     runs-on: ${{ matrix.os }}
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os:
           - macOS-latest
-          - ubuntu-20.04
+          - ubuntu-22.04
           - windows-2022
         toolchain:
           - "1.75"
@@ -90,7 +90,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-24.04
         toolchain:
           - "1.75"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ http-body-util = "0.1"
 hyper = { version = "1.1", features = ["client", "http1", "http2"] }
 hyper-tls = "0.6.0"
 hyper-util = { version = "0.1", features = ["http1", "http2"] }
-futures = "0.3"
 log = "0.4"
 time = { version = "0.3", features = ["parsing"] }
 thiserror = "1.0"
@@ -46,7 +45,6 @@ openssl = "0.10.35"
 passivized_htpasswd = "0.0.6"
 passivized_test_support = "0.0.11"
 rand = "0.8"
-simple_logger = { version = "4.3", default-features = false, features = ["timestamps", "threads"] }
 tar = "0.4"
 thiserror = "1.0"
 tempfile = "3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "passivized_docker_engine_client"
 readme = "README.md"
 repository = "https://github.com/iamjpotts/passivized_docker_engine_client"
-rust-version = "1.88"
+rust-version = "1.89"
 version = "0.0.10-alpha"
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MPL-2.0"
 name = "passivized_docker_engine_client"
 readme = "README.md"
 repository = "https://github.com/iamjpotts/passivized_docker_engine_client"
-rust-version = "1.75"
+rust-version = "1.88"
 version = "0.0.10-alpha"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ repository = "https://github.com/iamjpotts/passivized_docker_engine_client"
 rust-version = "1.88"
 version = "0.0.10-alpha"
 
+[lints.clippy]
+to_string_trait_impl = "allow"
+uninlined_format_args = "allow"
+
 [dependencies]
 base64 = "0.21"
 byteorder = "1.4"

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,11 @@
 
 [advisories]
-ignore = []
+ignore = [
+    # instant is now unmaintained
+    "RUSTSEC-2024-0384",
+    # backoff is now unmaintained
+    "RUSTSEC-2025-0012",
+]
 version = 2
 
 # This library uses the MPL-2 license.
@@ -9,10 +14,9 @@ version = 2
 [licenses]
 allow = [
     "Apache-2.0",
-    "BSD-3-Clause",
     "MIT",
     "MPL-2.0",
-    "Unicode-DFS-2016",
+    "Unicode-3.0",
 ]
 confidence-threshold = 1.0
 version = 2

--- a/src/responses/inspect_container.rs
+++ b/src/responses/inspect_container.rs
@@ -160,7 +160,8 @@ pub struct InspectedContainerConfig {
     #[serde(rename = "MacAddress")]
     pub mac_address: Option<String>,
 
-    #[serde(rename = "OnBuild", deserialize_with = "dz_vec")]
+    /// Not always present for images built with buildkit
+    #[serde(rename = "OnBuild", default, deserialize_with = "dz_vec")]
     pub on_build: Vec<String>,
 
     #[serde(rename = "Labels")]


### PR DESCRIPTION
Dust off an old package.

* `OnBuild` container config field is no longer always provided, e.g. absent in the inspection result of some containers built using buildkit
* Rust 1.75 -> 1.88
* Ubuntu 20.04 -> 22.04 for min ci version
* Disable ci for Windows and MacOS temporarily; their docker services docker no longer support docker client version 1.41 used by this crate and their mininum version 1.44 requires a breaking change related to stdout/stderr streaming
* Define clippy exceptions to allow current code style
* Remove references to some crates that were not used directly
* Refresh cargo deny allowances